### PR TITLE
Basic test client parameter for modifying data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
       #       aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
       #       source dev_env.sh
       #       source /usr/local/share/virtualenvs/tap-tester/bin/activate
+      #       pip install .[dev] # Install tap for the test client subclass usage
       #       run-test --tap=tap-adroll \
       #                --target=target-stitch \
       #                --orchestrator=stitch-orchestrator \

--- a/tap_adroll/client.py
+++ b/tap_adroll/client.py
@@ -35,7 +35,8 @@ class AdrollClient():
                                      token_updater=self._write_config)
         try:
             # Make an authenticated request after creating the object to any endpoint
-            self.get('organization/get')
+            org = self.get('organization/get').get('results', {}).get('eid')
+            self.organization_eid = org
         except Exception as e:
             LOGGER.info("Error initializing AdrollClient during token refresh, please reauthenticate.")
             raise AdrollAuthenticationError(e)
@@ -58,7 +59,7 @@ class AdrollClient():
                           (requests.exceptions.HTTPError),
                           max_tries=3,
                           interval=10)
-    def _make_request(self, method, endpoint, headers=None, params=None):
+    def _make_request(self, method, endpoint, headers=None, params=None, data=None):
         full_url = ENDPOINT_BASE + endpoint
         LOGGER.info(
             "%s - Making request to %s endpoint %s, with params %s",
@@ -69,7 +70,7 @@ class AdrollClient():
         )
 
         # TODO: We should merge headers with some default headers like user_agent
-        response = self.session.request(method, full_url, headers=headers, params=params)
+        response = self.session.request(method, full_url, headers=headers, params=params, data=data)
 
         response.raise_for_status()
         # TODO: Check error status, rate limit, etc.

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,9 +2,8 @@ import os
 import unittest
 
 import tap_tester.connections as connections
-from oauthlib.oauth2 import LegacyApplicationClient
-from requests_oauthlib import OAuth2Session
 
+from test_client import TestClient
 
 class TestAdrollBase(unittest.TestCase):
     REPLICATION_KEYS = "valid-replication-keys"
@@ -39,18 +38,8 @@ class TestAdrollBase(unittest.TestCase):
             'start_date' : '2020-03-01T00:00:00Z'
         }
 
-    @staticmethod
-    def get_credentials():
-        # Get a refresh token with password credentials
-        client_id = os.getenv('TAP_ADROLL_CLIENT_ID')
-        client_secret = os.getenv('TAP_ADROLL_CLIENT_SECRET')
-        username = os.getenv('TAP_ADROLL_USERNAME')
-        password = os.getenv('TAP_ADROLL_PASSWORD')
-
-        oauth = OAuth2Session(client=LegacyApplicationClient(client_id=client_id))
-        token = oauth.fetch_token(token_url='https://services.adroll.com/auth/token',
-                                  username=username, password=password, client_id=client_id,
-                                  client_secret=client_secret)
+    def get_credentials(self):
+        token = TestClient.get_token_information()
         return {
             'refresh_token': token['refresh_token'],
             'client_id': client_id,

--- a/tests/test_adroll_full_replication.py
+++ b/tests/test_adroll_full_replication.py
@@ -5,6 +5,7 @@ import unittest
 import json
 
 from base import TestAdrollBase
+from test_client import TestClient
 
 class TestAdrollFullReplication(TestAdrollBase):
     def name(self):
@@ -36,6 +37,19 @@ class TestAdrollFullReplication(TestAdrollBase):
             self, conn_id, self.expected_streams(), self.expected_primary_keys())
         return sync_record_count
 
+
+    def setUp(self):
+        client = TestClient()
+        self.advertisable = client.create_advertisable()['results']
+        # Add other creation things beneath here for this advertisable (aka profile)
+        # Does deleting the advertisable cascade down it? or orphans them?
+
+    def tearDown(self):
+        resp = client.delete_advertisable(self.advertisable.get('eid'))
+        if resp.get('results') is not True:
+            raise Exception("WARNING Could not cleanup advertisable. eid: {}".format(self.advertisable.get('eid'))
+
+
     # Expected to fail because no data in adroll
     def test_run(self):
         """
@@ -56,7 +70,7 @@ class TestAdrollFullReplication(TestAdrollBase):
         #verify check  exit codes
         exit_status = menagerie.get_exit_status(conn_id, check_job_name)
         menagerie.verify_check_exit_status(self, exit_status, check_job_name)
-        
+
         # Select all streams and no fields within streams
         found_catalogs = menagerie.get_catalogs(conn_id)
         full_streams = {key for key, value in self.expected_replication_method().items()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,58 @@
+import os
+
+from oauthlib.oauth2 import LegacyApplicationClient
+from requests_oauthlib import OAuth2Session
+
+from tap_adroll.client import AdrollClient
+
+class TestClient(AdrollClient):
+    """ A client subclass to implement the data manipulation endpoints for the tap. """
+
+    def __init__(self):
+        token = self.get_token_information()
+        config = {
+            'access_token': token['access_token'],
+            'refresh_token': token['refresh_token'],
+            'client_id': os.getenv('TAP_ADROLL_CLIENT_ID'),
+            'client_secret': os.getenv('TAP_ADROLL_CLIENT_SECRET')
+        }
+        super().__init__('/dev/null', config)
+
+
+    def _write_config(self, token):
+        # Not needed
+        pass
+
+    @staticmethod
+    def get_token_information():
+        # Get a refresh token with password credentials
+        client_id = os.getenv('TAP_ADROLL_CLIENT_ID')
+        client_secret = os.getenv('TAP_ADROLL_CLIENT_SECRET')
+        username = os.getenv('TAP_ADROLL_USERNAME')
+        password = os.getenv('TAP_ADROLL_PASSWORD')
+
+        oauth = OAuth2Session(client=LegacyApplicationClient(client_id=client_id))
+        return oauth.fetch_token(token_url='https://services.adroll.com/auth/token',
+                                 username=username, password=password, client_id=client_id,
+                                 client_secret=client_secret)
+
+
+    def create_advertisable(self):
+        # does our test account even let us do this?
+        data = {'name': 'Test', 'organization': self.organization_eid, 'product_name': 'Testing Product'}
+        resp = self.post('advertisable/create', data=data)
+        return resp
+
+    def delete_advertisable(self, advertisable_eid):
+        resp = self.delete('advertisable/deactivate', data={'advertisable': advertisable_eid})
+        return resp
+
+
+    def post(self, url, headers=None, params=None, data=None):
+        return self._make_request("POST", url, headers=headers, params=params, data=data)
+
+
+    def delete(self, url, headers=None, params=None, data=None):
+        # Deleting as we've seen it thus far is a POST
+        return self._make_request("POST", url, headers=headers, params=params, data=data)
+    


### PR DESCRIPTION
# Description of change
We'd like to have a standard way of modifying, creating, and deleting data for tap-tester tests here, so this PR has a pattern that subclasses the tap's `get` client and adds on the rest of the operations to be used in test.

It keeps the credentials separate from the tap so that the refresh token chain does not break.

# Manual QA steps
 - Ran through a create and delete advertisable example and it seems to have worked.
 
# Risks
 - Low, but care must be taken to not delete the advertisable `RJMetrics`, which appears to be test data used for the Sourcerer integration.
 
# Rollback steps
 - revert this branch
