### PR TITLE
Testing/add segments

### DIFF
--- a/tap_adroll/client.py
+++ b/tap_adroll/client.py
@@ -59,8 +59,11 @@ class AdrollClient():
                           (requests.exceptions.HTTPError),
                           max_tries=3,
                           interval=10)
-    def _make_request(self, method, endpoint, headers=None, params=None, data=None):
+    def _make_request(self, method, endpoint, headers=None, params=None, data=None, override_api=None):
         full_url = ENDPOINT_BASE + endpoint
+        if override_api:
+            full_url = full_url.replace('api', override_api)
+
         LOGGER.info(
             "%s - Making request to %s endpoint %s, with params %s",
             full_url,

--- a/tests/base.py
+++ b/tests/base.py
@@ -216,7 +216,20 @@ class TestAdrollBase(unittest.TestCase):
                     return date_stripped
                 except ValueError:
                     try:
-                        date_stripped = dt.strptime(date_value, "%Y-%m-%dT%H:%M:%S.000000Z")
+                        date_stripped = dt.strptime(date_value, "%Y-%m-%dT%H:%M:%S+0000")
                         return date_stripped
                     except ValueError:
-                        raise NotImplementedError
+                        try:
+                            date_stripped = dt.strptime(date_value, "%Y-%m-%dT%H:%M:%S.000000Z")
+                            return date_stripped
+                        except ValueError:
+                            raise NotImplementedError
+
+    def modify_expected_dates(self, expected_records):
+        """datetime values must conform to ISO-8601 or they will be rejected by the gate"""
+        for record in expected_records:
+            for key, value in record.items():
+                if key == 'created_date':
+                    raw_date = self.parse_date(value)
+                    iso_date = dt.strftime(raw_date,  "%Y-%m-%dT%H:%M:%S.000000Z")
+                    record[key] = iso_date

--- a/tests/client_tester.py
+++ b/tests/client_tester.py
@@ -12,8 +12,8 @@ if __name__ == "__main__":
     client = TestClient()
 
     # CHANGE FLAGS HERE TO TEST SPECIFIC FUNCTION TYPES
-    test_creates = True
-    test_updates = False
+    test_creates = False
+    test_updates = True
     test_gets = False
     test_deletes = False
 
@@ -21,11 +21,11 @@ if __name__ == "__main__":
     print_objects = True
 
     objects_to_test = [ # CHANGE TO TEST DESIRED STREAMS 
-        'segments', # GET - DONE | CREATE - DONE
+
     ]
     # 'ads', # GET - DONE | CREATE - DONE | UPDATE - DONE
     # 'ad_groups', # GET - DONE | CREATE - DONE | UPDATE - DONE
-
+    # 'segments', # GET - DONE | CREATE - DONE | UPDATE - DONE
     # 'campaigns', # GET - DONE | CREATE - DONE | UPDATES - DONE
     # 'advertisables', # GET - DONE | CREATE NA (DONT DO THIS ONE)
     # 'ad_reports', GET - DONE | CREATE - N/A

--- a/tests/client_tester.py
+++ b/tests/client_tester.py
@@ -12,8 +12,8 @@ if __name__ == "__main__":
     client = TestClient()
 
     # CHANGE FLAGS HERE TO TEST SPECIFIC FUNCTION TYPES
-    test_creates = False
-    test_updates = True
+    test_creates = True
+    test_updates = False
     test_gets = False
     test_deletes = False
 
@@ -21,11 +21,12 @@ if __name__ == "__main__":
     print_objects = True
 
     objects_to_test = [ # CHANGE TO TEST DESIRED STREAMS 
-        'campaigns', # GET - DONE | CREATE - DONE (werid  RATE LIMIT) | UPDATES - DONE
+        'segments', # GET - DONE | CREATE - DONE
     ]
     # 'ads', # GET - DONE | CREATE - DONE | UPDATE - DONE
     # 'ad_groups', # GET - DONE | CREATE - DONE | UPDATE - DONE
-    # 'segments', # GET - DONE | CREATE - INPROGRESS need to implement audience endpoint jawn
+
+    # 'campaigns', # GET - DONE | CREATE - DONE | UPDATES - DONE
     # 'advertisables', # GET - DONE | CREATE NA (DONT DO THIS ONE)
     # 'ad_reports', GET - DONE | CREATE - N/A
 
@@ -39,7 +40,6 @@ if __name__ == "__main__":
             if existing_obj:
                 print("SUCCESS")
                 if print_objects:
-                    import pdb; pdb.set_trace()
                     print(existing_obj)
                 continue
             print("FAILED")

--- a/tests/test_adroll_all_fields.py
+++ b/tests/test_adroll_all_fields.py
@@ -20,7 +20,7 @@ class TestAdrollAllFields(TestAdrollBase):
 
     def testable_streams(self):
         return set(self.expected_streams()).difference(
-            {'ad_reports','segments'} # STREAMS THAT CANNOT CURRENTLY BE TESTED
+            {'ad_reports'} # STREAMS THAT CANNOT CURRENTLY BE TESTED
         )
 
     @classmethod
@@ -51,6 +51,11 @@ class TestAdrollAllFields(TestAdrollBase):
             else:
                print("Data does not exist for stream: {}".format(stream))
                assert None, "more test functinality needed"
+
+        # modify data set to conform to expectations (json standards)
+        for stream, records in expected_records.items():
+            print("Ensuring expected data for {} has datetime objects formatted correctly.".format(stream))
+            self.modify_expected_dates(records)
 
         # Instantiate connection with default start/end dates
         conn_id = connections.ensure_connection(self)
@@ -117,8 +122,11 @@ class TestAdrollAllFields(TestAdrollBase):
             with self.subTest(stream=stream):
                 data = synced_records.get(stream)
                 record_messages_keys = [set(row['data'].keys()) for row in data['messages']]
-                expected_keys = expected_records.get(stream)[0].keys()
-
+                expected_keys = list(expected_records.get(stream)[0].keys())
+                if stream == 'segments': # Ensure all keys accounted for
+                    for record in expected_records.get(stream):
+                        keys = record.keys()
+                        expected_keys += [key for key in keys if key not in expected_keys]
 
                 # Verify schema covers all fields
                 schema_keys = set(self.expected_schema_keys(stream))
@@ -134,11 +142,12 @@ class TestAdrollAllFields(TestAdrollBase):
                 if schema_keys.difference(set(expected_keys)):
                     print("WARNING Fields missing from expectations: {}".format(schema_keys.difference(set(expected_keys))))
 
-                # Verify that all fields are sent to the target
+                # Verify that all fields sent to the target fall into the expected schema
                 for actual_keys in record_messages_keys:
-                    self.assertEqual(
-                        actual_keys.symmetric_difference(schema_keys), set(),
-                        msg="Expected all fields, as defined by schemas/{}.json".format(stream))
+                    self.assertTrue(
+                        actual_keys.issubset(schema_keys),
+                        msg="Expected all fields to be present, as defined by schemas/{}.json".format(stream) +
+                        "EXPECTED (SCHEMA): {}\nACTUAL (REPLICATED KEYS): {}".format(schema_keys, actual_keys))
 
                 actual_records = [row['data'] for row in data['messages']]
 
@@ -150,14 +159,26 @@ class TestAdrollAllFields(TestAdrollBase):
 
                 # verify by values, that we replicated the expected records
                 for actual_record in actual_records:
+                    if not actual_record in expected_records.get(stream):
+                        print("DATA DISCREPANCY")
+                        print("Actual: {}".format(actual_record))
+                        e_record = [record for record in expected_records.get(stream)
+                                    if actual_record.get('eid') == record.get('eid')]
+                        print("Expected: {}".format(e_record))
                     self.assertTrue(actual_record in expected_records.get(stream),
-                                    msg="Actual record missing from expectations")
-                for expected_record in expected_records.get(stream):
-                    self.assertTrue(expected_record in actual_records,
-                                    msg="Expected record missing from target.")
+                                    msg="Actual record missing from expectations.\n" +
+                                    "ACTUAL {}".format(actual_record))
 
-        # TODO Remove when test complete
-        print("\n\n\tTOOD's PRESENT | The test is incomplete\n\n")
+                for expected_record in expected_records.get(stream):
+                    if not expected_record in actual_records:
+                        print("DATA DISCREPANCY")
+                        print("Expected: {}".format(expected_record))
+                        a_record = [record for record in actual_records
+                                    if expected_record.get('eid') == record.get('eid')]
+                        print("Actual: {}".format(a_record))
+                    self.assertTrue(expected_record in actual_records,
+                                    msg="Expected record missing from target.\n" +
+                                    "EXPECTED {}".format(expected_record))
 
 
 if __name__ == '__main__':

--- a/tests/test_adroll_automatic_fields.py
+++ b/tests/test_adroll_automatic_fields.py
@@ -168,9 +168,6 @@ class TestAdrollAutomaticFields(TestAdrollBase):
                     self.assertTrue(expected_record in actual_records,
                                     msg="Expected record missing from target.")
 
-        # TODO Remove when test complete
-        print("\n\n\tTOOD's PRESENT | The test is incomplete\n\n")
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_adroll_start_date_full_table.py
+++ b/tests/test_adroll_start_date_full_table.py
@@ -21,8 +21,8 @@ class TestAdrollStartDateFullTable(TestAdrollBase):
         return "tap_tester_adroll_start_date_full_table"
 
     def testable_streams(self):
-        return self.expected_full_table_streams().difference({ # STREAMS THAT CANNOT CURRENTLY BE TESTED
-            'advertisables', 'segments'
+        return self.expected_full_table_streams().difference({
+            'advertisables',  # STREAMS THAT CANNOT CURRENTLY BE TESTED
         })
 
     @classmethod
@@ -35,26 +35,6 @@ class TestAdrollStartDateFullTable(TestAdrollBase):
     def tearDownClass(cls):
         print("\n\nTEST TEARDOWN\n\n")
 
-
-    def parse_date(self, date_value):
-        try:
-            date_stripped = dt.strptime(date_value, "%Y-%m-%dT%H:%M:%SZ")
-            return date_stripped
-        except ValueError:
-            try: 
-                date_stripped = dt.strptime(date_value, "%Y-%m-%dT%H:%M:%S+0000Z")
-                return date_stripped
-            except ValueError:
-                raise NotImplementedError
-
-    def timedelta_formatted(self, dtime, days=0):
-        try:
-            date_stripped = dt.strptime(dtime, self.START_DATE_FORMAT)
-            return_date = date_stripped + timedelta(days=days)
-            return dt.strftime(return_date, self.START_DATE_FORMAT)
-
-        except ValueError:
-            return Exception("Datetime object is not of the format: {}".format(self.START_DATE_FORMAT))
 
     def test_run(self):
         print("\n\nRUNNING {}\n\n".format(self.name()))
@@ -215,7 +195,6 @@ class TestAdrollStartDateFullTable(TestAdrollBase):
                                      "Sync 2 start_date: {} ".format(start_date_2) + 
                                      "Sync 2 record_count: {}".format(record_count_2))
 
-
                     # Verify all records in the 1st sync are included in the 2nd sync since
                     # 2nd sync has a later start date.
                     records_from_sync_1 = set(row.get('data').get('eid')
@@ -226,28 +205,11 @@ class TestAdrollStartDateFullTable(TestAdrollBase):
                                      msg="Sync 2 record(s) missing from Sync 1:\n{}".format(
                                          records_from_sync_2.difference(records_from_sync_1))
                     )
-                    # self.assertEqual(set(), records_from_sync_1.difference(records_from_sync_2),
-                    #                  msg="Sync 1 record(s) missing from Sync 2:\n{}".format(
-                    #                      records_from_sync_1.difference(records_from_sync_2))
-                    # )
-
-                    """
-                    expected = set(record.get('eid') for record in expected_records_1.get(stream))
-                    acutal = set(row.get('data').get('eid')
-                                 for row in synced_records_1.get(stream, []).get('messages', []))
-                    self.assertEqual(set(), expected.difference(actual),
-                                     msg="Expected record(s) not replicated:\n{}".format(expected.difference(actual)))
-                    self.assertEqual(set(), actual.difference(expected),
-                                     msg="Unexpected record(s) replicated:\n{}".format(expected.difference(actual)))
-                    """
 
                 else:
                     raise Exception("Expectations are set incorrectly. {} cannot have a "
                                     "replication method of {}".format(stream, replication_type))
                     
-        # TODO Remove when test complete
-        print("\n\n\tTOOD's PRESENT | The test is incomplete\n\n")
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -195,7 +195,7 @@ class TestClient(AdrollClient):
         elif stream == 'campaigns':
             return self.create_campaign()
         elif stream == 'segments':
-            raise NotImplementedError  #return self.create_segment()
+            return self.create_segment()
         elif stream == 'ad_groups':
            campaign_eid = random.choice(self.get_all_campaigns()).get('eid')
            return self.create_ad_group(campaign_eid)
@@ -232,26 +232,44 @@ class TestClient(AdrollClient):
         resp = self.post('ad/create', data=data)
         return resp.get('results')
 
-    # def create_segment(self):
-    #     tstamp = str(dt.utcnow().timestamp())
-    #     data = {
-    #         'advertisable': self.ADVERTISABLE_EID,
-    #         'name': 'SEGMENT {}'.format(tstamp[:-7]),
-    #         'conversion_value': None,
-    #         'duration': random.randint(1,30),
-    #         'type': 'p',
-    #         # 'data': [
-    #         #   {
-    #         #     'email': '',
-    #         #     'id': 'string'
-    #         #   }
-    #         # ],
-    #         # 'general_exclusion_type': 'string',
-    #         # 'is_conversion': False,
-    #         # 'sfdc_company_list_id': 'string',
-    #     }
-    #     resp = self.post('/segments', data=data) # REQUIRES DIFFERENT BASE ENDPOINT
-    #     return resp.get('results')
+    def create_segment(self):
+        # Create segment via 'audience' api
+        tstamp = str(dt.utcnow().timestamp())
+        query_params = {
+            'advertiser_id': self.ADVERTISABLE_EID,
+            'type': 'custom',
+            'name': 'SEGMENT {}'.format(tstamp[:-7]),
+            'duration': random.randint(1,30),
+        }
+        new_segment_resp = self.post('segments', params=query_params, override_api='audience') # REQUIRES DIFFERENT BASE ENDPOINT
+        result = new_segment_resp.get('result').lower()
+        assert result == 'success', "Result of attempted create: {}".format(result)
+
+        # Add segment to adgroup
+        adgroup_eid = random.choice(self.get_all_ad_groups()).get('eid')
+        new_segment_id = new_segment_resp.get('segment', {}).get('segment_id')
+        assert new_segment_id, "Segment was not created successfully, or the api has changed the return for this create"
+        query_params = {
+            'segments': new_segment_id, # 'QUFXJWKZRJGDDPIXDD8SEG',
+            'adgroup': adgroup_eid,
+        }
+        added_segment_resp = self.put('adgroup/add_segments', params=query_params).get('results')
+        if not added_segment_resp:
+            raise Exception("Falied to add segment to adgroup\nparams: {}".format(query_params))
+
+        # Get all segments from adgroups
+        self.SEGMENTS = None # reset to None to get newer segements
+        all_segments = self.get_all_segments()
+        matching_segments = [segment for segment in all_segments if segment.get('eid') == new_segment_id]
+        if not matching_segments:
+            import pdb; pdb.set_trace()
+        if len(matching_segments) != 1:
+            import pdb; pdb.set_trace()
+        assert matching_segments, "Segment was not successfully attached to an adgroup"
+        assert len(matching_segments) == 1, "Segment is attached to multiple adgroups"
+
+        # return the correctly formatted expected record
+        return matching_segments.pop()
 
     def create_campaign(self):
         tstamp = dt.utcnow().timestamp()
@@ -343,12 +361,12 @@ class TestClient(AdrollClient):
     #     return resp
 
 
-    def get(self, url, headers=None, params=None, data=None):
-        return self._make_request("GET", url, headers=headers, params=params)
+    def get(self, url, headers=None, params=None, data=None, override_api=None):
+        return self._make_request("GET", url, headers=headers, params=params, override_api=override_api)
 
 
-    def post(self, url, headers=None, params=None, data=None):
-        return self._make_request("POST", url, headers=headers, params=params, data=data)
+    def post(self, url, headers=None, params=None, data=None, override_api=None):
+        return self._make_request("POST", url, headers=headers, params=params, data=data, override_api=override_api)
 
     def put(self, url, headers=None, params=None, data=None):
         return self._make_request("PUT", url, headers=headers, params=params, data=data)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -306,7 +306,7 @@ class TestClient(AdrollClient):
         elif stream == 'campaigns':
             return self.update_campaign(eid)
         elif stream == 'segments':
-            raise NotImplementedError  #return self.create_segment()
+            return self.update_segment(eid)
         elif stream == 'ad_groups':
             return self.update_ad_group(eid)
         else:
@@ -352,6 +352,17 @@ class TestClient(AdrollClient):
         resp = self.put('campaign/edit', data=data)
         return resp.get('results')
 
+    def update_segment(self, eid):
+        tstamp = str(dt.utcnow().timestamp())
+        if eid is None:
+            eid = random.choice(self.get_all_segments()).get('eid')
+        data = {
+            'segment': eid,
+            'name': 'updated_segment_{}'.format(tstamp[:-7]), # name is lowered in return val, and does not accept spaces here
+        }
+        resp = self.put('segment/edit', data=data)
+        return resp.get('results')
+
 
     # NB: Commented create and deletes since AdRoll as of now, doesn't
     # seem to have a true "DELETE" in their CRUD
@@ -363,7 +374,6 @@ class TestClient(AdrollClient):
 
     def get(self, url, headers=None, params=None, data=None, override_api=None):
         return self._make_request("GET", url, headers=headers, params=params, override_api=override_api)
-
 
     def post(self, url, headers=None, params=None, data=None, override_api=None):
         return self._make_request("POST", url, headers=headers, params=params, data=data, override_api=override_api)


### PR DESCRIPTION
# Description of change
Add CRUD for `segments` stream. This includes a change to the tap client.
Ensure existing tests are covering `segments` stream
# Manual QA steps
 - Ran tests locally and in Cirlce
 
# Risks
 - Low, added a parameter to the make request method which defaults to None, but will change the endpoint if given a string value
 
# Rollback steps
 - revert this branch
