### PR TITLE
added new fields in advertisables and campaigns streams

### DIFF
--- a/tap_adroll/schemas/advertisables.json
+++ b/tap_adroll/schemas/advertisables.json
@@ -22,6 +22,18 @@
         "string"
       ]
     },
+    "is_html5_enabled": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "ecomm_platform_plan": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "rollcrawl_enabled": {
       "type": [
         "null",

--- a/tap_adroll/schemas/campaigns.json
+++ b/tap_adroll/schemas/campaigns.json
@@ -22,6 +22,12 @@
         "string"
       ]
     },
+    "billing_auth_status": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "bid_strategy": {
       "type": [
         "null",


### PR DESCRIPTION
# Description of change
Added new fields in the below streams :
- `advertisables`: is_html5_enabled and ecomm_platform_plan
- `campaigns`: billing_auth_status

# Manual QA steps
 Execute the tap-tester scenarios to validate the changes done.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
